### PR TITLE
Fix version information disclosure in Express server

### DIFF
--- a/src/apps/ui/src/server.ts
+++ b/src/apps/ui/src/server.ts
@@ -10,6 +10,7 @@ const browserDistFolder = resolve(serverDistFolder, '../browser');
 const indexHtml = join(serverDistFolder, 'index.server.html');
 
 const app = express();
+app.disable("x-powered-by");
 const commonEngine = new CommonEngine();
 
 /**


### PR DESCRIPTION
Fixes #26

Disable the `x-powered-by` header to prevent version information disclosure.

* Add `app.disable("x-powered-by");` after `const app = express();` in `src/apps/ui/src/server.ts` on line 13

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jtoniolo/email_sweeperr/pull/27?shareId=9cd87a8c-54de-4dc4-83df-3ce36d9e8573).