### PR TITLE
Implement API versioning

### DIFF
--- a/src/apps/api/src/main.ts
+++ b/src/apps/api/src/main.ts
@@ -3,7 +3,7 @@
  * This is only a minimal backend to get started.
  */
 
-import { Logger } from '@nestjs/common';
+import { Logger, VersioningType } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app/app.module';
 import session from 'express-session';
@@ -21,6 +21,10 @@ async function bootstrap() {
   });
   const globalPrefix = 'api';
   app.setGlobalPrefix(globalPrefix);
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: '1',
+  });
   app.enableCors({
     origin: process.env.CORS_ORIGINS.split(',')
       .map((origin) => origin.trim())

--- a/src/apps/ui/public/config.json
+++ b/src/apps/ui/public/config.json
@@ -1,3 +1,3 @@
 {
-  "apiBaseUrl": "http://localhost:3000"
+  "apiBaseUrl": "http://localhost:3000/api/v1"
 }

--- a/src/apps/ui/public/config.local.json
+++ b/src/apps/ui/public/config.local.json
@@ -1,3 +1,3 @@
 {
-  "apiBaseUrl": "http://localhost:3000"
+  "apiBaseUrl": "http://localhost:3000/api/v1"
 }

--- a/src/apps/ui/src/app/welcome/welcome.component.ts
+++ b/src/apps/ui/src/app/welcome/welcome.component.ts
@@ -16,7 +16,7 @@ export class WelcomeComponent {
   signUpWithGoogle(): void {
     this.#facade.apiBaseUrl$.subscribe((apiBaseUrl) => {
       this.document.open(
-        apiBaseUrl + '/api/auth/google',
+        apiBaseUrl + '/auth/google',
         'Authenticate with Google',
         'width=500,height=600'
       );


### PR DESCRIPTION
Fixes #20

Implement API versioning in the NestJS API.

* **Enable versioning**: Import `VersioningType` from `@nestjs/common` in `src/apps/api/src/main.ts`.
* **Set default version**: Enable versioning in the `main.ts` file using `VersioningType.URI` and set the default version to `1`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jtoniolo/email_sweeperr/pull/28?shareId=2509bc45-08dd-47ea-84c5-1e00e72c9ddd).